### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# run with below commands:
+# docker build -t jumpflix .
+# docker run --rm -p 5173:5173 -v $(pwd):/app -v /app/node_modules jumpflix
+
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host"]


### PR DESCRIPTION
Just thought I'd add some code to make it easier to bring up the dev stack locally

- Avoid needing to install Node.JS environment locally
- Similarly, reduce risk of package collision with global `npm` with other projects

You can achieve similar effect via a `docker-compose.yml` file too and just run `docker-compose up`:
```Dockerfile
version: "3.9"

services:
  app:
    image: node:20-alpine
    working_dir: /app
    volumes:
      - .:/app
      - /app/node_modules
    ports:
      - "5173:5173"
    command: sh -c "npm install && npm run dev -- --host"
```