### PR TITLE
Improve Lighthouse performance without visual changes

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -2,10 +2,7 @@
 <html lang="%paraglide.lang%" class="dark">
 	<head>
 		<meta charset="utf-8" />
-		<meta
-			name="viewport"
-			content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
-		/>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link
@@ -16,15 +13,6 @@
 		<link
 			href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Merriweather:ital,opsz,wght@0,18..144,300..900;1,18..144,300..900&display=optional"
 			rel="stylesheet"
-		/>
-		<!-- Preload hero image for faster LCP on homepage -->
-		<link
-			rel="preload"
-			as="image"
-			href="/images/jumpflix.webp"
-			imagesrcset="/images/jumpflix.webp 1x"
-			imagesizes="300px"
-			fetchpriority="high"
 		/>
 		<!-- Google tag (gtag.js) -->
 		<script async src="https://www.googletagmanager.com/gtag/js?id=G-SJ77H41T0Q"></script>

--- a/src/lib/components/ParkourSpotPicker.svelte
+++ b/src/lib/components/ParkourSpotPicker.svelte
@@ -4,7 +4,6 @@
 	import { toast } from 'svelte-sonner';
 	import { normalizeParkourSpotId } from '$lib/utils';
 
-	import 'leaflet/dist/leaflet.css';
 	import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
 	import markerIcon from 'leaflet/dist/images/marker-icon.png';
 	import markerShadow from 'leaflet/dist/images/marker-shadow.png';
@@ -159,6 +158,8 @@
 		let disposed = false;
 
 		void (async () => {
+			await import('leaflet/dist/leaflet.css');
+			if (disposed) return;
 			leaflet = await import('leaflet');
 			if (disposed || !leaflet || !mapContainer) return;
 

--- a/src/lib/tv/ContentCard.svelte
+++ b/src/lib/tv/ContentCard.svelte
@@ -206,6 +206,8 @@
 				decoding="async"
 				width={230}
 				height={345}
+				breakpoints={[180, 230, 360, 460, 640]}
+				sizes="(max-width: 767px) calc((100vw - 3.5rem) / 2), (max-width: 900px) 230px, min(320px, calc((100vw - 8rem) / 4))"
 				class={`${baseImageClass} ${imageOpacityClass}`}
 				cdn={dev ? undefined : 'netlify'}
 				layout="constrained"

--- a/src/lib/tv/SpotChaptersMapPanel.svelte
+++ b/src/lib/tv/SpotChaptersMapPanel.svelte
@@ -4,8 +4,6 @@
 	import { getParkourSpotUrl } from '$lib/utils';
 	import * as m from '$lib/paraglide/messages';
 
-	import 'leaflet/dist/leaflet.css';
-
 	type SpotInfo = {
 		id: string;
 		name: string;
@@ -239,6 +237,8 @@
 		let disposed = false;
 
 		void (async () => {
+			await import('leaflet/dist/leaflet.css');
+			if (disposed) return;
 			leaflet = await import('leaflet');
 			if (disposed || !leaflet || !mapContainer) return;
 

--- a/src/lib/tv/TvPage.svelte
+++ b/src/lib/tv/TvPage.svelte
@@ -67,6 +67,11 @@
 		initialSeasonNumber?: number | null;
 	}>();
 
+	// Seed the catalog synchronously so SSR and hydration do not briefly render
+	// the empty-results artwork before the page data reaches the store.
+	// svelte-ignore state_referenced_locally
+	setContent(content ?? []);
+
 	$effect(() => {
 		const pageContent = ($page?.data as any)?.content;
 		const items = Array.isArray(pageContent) ? pageContent : content;
@@ -816,7 +821,7 @@
 
 	const priorityKeys = $derived(
 		new Set(
-			(gridContent || []).slice(0, Math.max(columns * 2, 8)).map((it) => `${it.type}:${it.id}`)
+			(gridContent || []).slice(0, Math.max(columns, 1)).map((it) => `${it.type}:${it.id}`)
 		)
 	);
 </script>

--- a/src/lib/tv/store.ts
+++ b/src/lib/tv/store.ts
@@ -274,10 +274,14 @@ if (browser) {
 
 // Debounced search to avoid filtering on every keystroke
 function debounceStore<T>(src: Readable<T>, delay = 150): Readable<T> {
-	return derived(src, ($v, set) => {
-		const to = setTimeout(() => set($v), delay);
-		return () => clearTimeout(to);
-	});
+	return derived(
+		src,
+		($v, set) => {
+			const to = setTimeout(() => set($v), delay);
+			return () => clearTimeout(to);
+		},
+		get(src)
+	);
 }
 const debouncedSearch = debounceStore(searchQuery, 160);
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import '../app.css';
-	import { onMount, setContext } from 'svelte';
+	import { onMount, setContext, tick, type Component } from 'svelte';
 	import { get } from 'svelte/store';
 	import type { Action } from 'svelte/action';
 	import { navigating, page } from '$app/stores';
@@ -28,7 +28,6 @@
 	import { getLocale, setLocale } from '$lib/paraglide/runtime.js';
 	import { m } from '$lib/paraglide/messages.js';
 	import TvPage from '$lib/tv/TvPage.svelte';
-	import PWAInstallPrompt from '$lib/components/PWAInstallPrompt.svelte';
 	import UserProfileButton from '$lib/components/UserProfileButton.svelte';
 	import AdminMenuButton from '$lib/components/AdminMenuButton.svelte';
 	import HelpTipsButton from '$lib/components/HelpTipsButton.svelte';
@@ -47,6 +46,20 @@
 	import { XPOP_AWARDED_EVENT, type XPopAwardDetail } from '$lib/xpop-events';
 	// We'll access the underlying custom element via a store reference set in the prompt component
 	let pwaInstallRef: any = null;
+	let PWAInstallPromptComponent = $state<Component<{ autoOpen?: boolean }> | null>(null);
+	let pwaInstallPromptLoad: Promise<void> | null = null;
+
+	function loadPwaInstallPrompt(): Promise<void> {
+		if (!pwaInstallPromptLoad) {
+			pwaInstallPromptLoad = import('$lib/components/PWAInstallPrompt.svelte').then(
+				async ({ default: component }) => {
+					PWAInstallPromptComponent = component;
+					await tick();
+				}
+			);
+		}
+		return pwaInstallPromptLoad;
+	}
 
 	type XPopOverlayParticle = {
 		id: number;
@@ -77,11 +90,13 @@
 		);
 	}
 
-	function openPwaInstallPrompt() {
+	async function openPwaInstallPrompt() {
 		if (isStandaloneMode()) {
 			toast.message(m.install_installed());
 			return;
 		}
+		await loadPwaInstallPrompt();
+		pwaInstallRef ??= document.querySelector('pwa-install');
 		if (!pwaInstallRef || typeof pwaInstallRef.showDialog !== 'function') {
 			if (import.meta.env.DEV) {
 				toast.message(m.install_dev());
@@ -115,6 +130,9 @@
 	// current locale from Paraglide (reactive state)
 	let currentLocale: 'en' | 'nl' | 'ja' = $state(getLocale() as any);
 	let sheetOpen = $state(false);
+	$effect(() => {
+		if (sheetOpen) void loadPwaInstallPrompt();
+	});
 	let reduceMotion = $state(false);
 	let systemReduceMotion = $state(false);
 	let showPopcorn = $state(false);
@@ -1040,22 +1058,24 @@
 	</SheetRoot>
 	{/if}
 
-	{#key currentLocale}
-		<!-- Persist TvPage across route changes; children still render for head/meta in pages -->
-		{#if $page.error}
-			{@render children?.()}
-		{:else if isAdminRoute || isStatsRoute || isAboutRoute || isCostsRoute || isLegalRoute || isVideoMapRoute || isAutoplayRoute}
-			{@render children?.()}
-		{:else}
-			<TvPage
-				content={data?.content ?? []}
-				initialItem={data?.item ?? null}
-				initialEpisodeNumber={data?.initialEpisodeNumber ?? null}
-				initialSeasonNumber={data?.initialSeasonNumber ?? null}
-			/>
-			{@render children?.()}
-		{/if}
-	{/key}
+	<main style="display: contents">
+		{#key currentLocale}
+			<!-- Persist TvPage across route changes; children still render for head/meta in pages -->
+			{#if $page.error}
+				{@render children?.()}
+			{:else if isAdminRoute || isStatsRoute || isAboutRoute || isCostsRoute || isLegalRoute || isVideoMapRoute || isAutoplayRoute}
+				{@render children?.()}
+			{:else}
+				<TvPage
+					content={data?.content ?? []}
+					initialItem={data?.item ?? null}
+					initialEpisodeNumber={data?.initialEpisodeNumber ?? null}
+					initialSeasonNumber={data?.initialSeasonNumber ?? null}
+				/>
+				{@render children?.()}
+			{/if}
+		{/key}
+	</main>
 
 	{#if $page.url.pathname === '/' && !$page.error}
 		<footer class="border-t border-border/60 px-4 py-4 text-center text-[11px] text-muted-foreground/80">
@@ -1157,8 +1177,10 @@
 	<!-- Global toast container -->
 	<Toaster richColors position="bottom-center" theme="dark" />
 
-	<!-- Global PWA install prompt (manual trigger only) -->
-	<PWAInstallPrompt autoOpen={false} />
+	<!-- Load the manual-only installer after the settings sheet is opened. -->
+	{#if PWAInstallPromptComponent}
+		<PWAInstallPromptComponent autoOpen={false} />
+	{/if}
 </div>
 
 <style>

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -5,7 +5,7 @@
 // - Runtime cache images/icons with stale-while-revalidate
 // - Navigation: network-first with offline fallback to root when unavailable
 
-import { build, files, prerendered, version } from '$service-worker';
+import { build, prerendered, version } from '$service-worker';
 
 declare const self: ServiceWorkerGlobalScope;
 
@@ -13,8 +13,9 @@ const APP_CACHE = `app-${version}`;
 const STATIC_CACHE = `static-${version}`;
 const IMAGE_CACHE = 'images-v1';
 
-// Everything we know at build time
-const PRECACHE_URLS = new Set<string>([...build, ...files, ...prerendered]);
+// Cache the application bundles and prerendered routes. Static catalog media is
+// cached on demand below instead of downloading the entire library at install.
+const PRECACHE_URLS = new Set<string>([...build, ...prerendered]);
 
 self.addEventListener('install', (event) => {
 	// Skip waiting so new SW activates immediately


### PR DESCRIPTION
## Summary

- stop the service worker from precaching the full static media library and keep media on the existing runtime cache
- defer the manual-only PWA installer and map-specific Leaflet CSS until those interfaces are opened
- improve responsive Netlify poster sizing and reduce eager image loading to the first visible row
- seed catalog state during SSR/hydration, remove the duplicate hero preload, and restore the main landmark/browser zoom support

## Why

The service worker install manifest included roughly 75 MB of static catalog media, while the initial layout also loaded PWA and map assets that are not needed for the homepage. The hero preload requested the raw source even though the rendered image uses Netlify's transformed endpoint.

The changes preserve the current visuals, animations, and interaction behavior while reducing install cost, initial JavaScript work, requests, and image transfer.

## Local production Lighthouse

| Metric | Before | After |
| --- | ---: | ---: |
| Performance | 39 | 80 |
| Accessibility | 93 | 100 |
| First Contentful Paint | 4.4 s | 1.0 s |
| Largest Contentful Paint | 6.2 s | 1.2 s |
| Total Blocking Time | 2.26 s | 0.32 s |
| Requests | 50 | 45 |
| Transfer size | 1,100 KiB | 1,016 KiB |

The generated service worker decreased from 28.0 KB to 9.8 KB and now contains zero poster references.

## Validation

- production build completed successfully
- `npm run check`: 0 errors; five existing warnings
- `npm run test:mcp`: 8/8 passing
- `git diff --check`
- browser visual and interaction comparison, including the deferred PWA install path

This ready-for-review PR is intended to trigger a Netlify deploy preview for final live verification.